### PR TITLE
Use sha256

### DIFF
--- a/credulous.rb
+++ b/credulous.rb
@@ -4,7 +4,7 @@ class Credulous < Formula
   homepage 'https://github.com/realestate-com-au/credulous'
   version '0.2.1'
   url "https://github.com/realestate-com-au/credulous/releases/download/#{version}/credulous-#{version}.131-osx.tgz"
-  sha1 '27e6b2f431b04b051cba896ee85744ee2ad5d326'
+  sha256 '42ac207b8ef19509986d3a7eda3832f2466bf79ad3cbaa241986dc653e22daf9'
 
   def install
     bin.install "credulous"

--- a/libgit2-0.21.0.rb
+++ b/libgit2-0.21.0.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libgit2 < Formula
   homepage 'http://libgit2.github.com/'
   url 'https://github.com/libgit2/libgit2/archive/v0.21.0.tar.gz'
-  sha1 '1534ecba1116ce8866e980499b2a3b5e67909bee'
+  sha256 '3b89614791fbaebfd1bfe1b7fa963caff394d06d48f42966e7456363d9c34d6a'
 
   head 'https://github.com/libgit2/libgit2.git', :branch => 'master'
 


### PR DESCRIPTION
Installing failed for me due to sha1 being deprecated by homebrew. 
This fixes it. 

[Homebrew sha1 deprecation notice](https://docs.brew.sh/Checksum_Deprecation.html)

```
$ brew --version
Homebrew 1.3.8
Homebrew/homebrew-core (git revision eef6; last commit 2017-12-01)

$ brew install https://raw.githubusercontent.com/realestate-com-au/credulous-brew/master/credulous.rb
######################################################################## 100.0%
Error: Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/Users/admin/Library/Caches/Homebrew/Formula/credulous.rb:7:in `<class:Credulous>'
```